### PR TITLE
Update passwordservice.php

### DIFF
--- a/service/passwordservice.php
+++ b/service/passwordservice.php
@@ -126,7 +126,7 @@ class PasswordService {
      */
     class Encryption {
 
-        public function makeKey($userKey, $serverKey, $userSuppliedKey) {
+        public static function makeKey($userKey, $serverKey, $userSuppliedKey) {
             $key = hash_hmac('sha512', $userKey, $serverKey);
             $key = hash_hmac('sha512', $key, $userSuppliedKey);
             return $key;


### PR DESCRIPTION
On owncloud log appears an error:
Error 	PHP 	Non-static method OCA\Passwords\Service\Encryption::makeKey() should not be called statically, assuming $this from incompatible context at /var/www/owncloud/apps/passwords/service/passwordservice.php#34.


This change should fix it....