### PR TITLE
Fixing a bug with oC 8.2.1

### DIFF
--- a/templates/main.php
+++ b/templates/main.php
@@ -4,7 +4,7 @@
 		$url = 'http://' . $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI'];
 
 		if (false !== strpos($url,'d=1')) {
-			OC_Log::write('passwords', 'Passwords app accessed without secure connection.', OC_Log::WARN);
+			OCP\Util::writeLog(write('passwords', 'Passwords app accessed without secure connection.', OCP\Util::WARN);
 		    return true;
 		}
 
@@ -45,8 +45,7 @@
 	</div>
 
 <?php } else {
-		
-		OC_Log::write('passwords', 'Passwords app blocked; no secure connection.', OC_Log::ERROR);
+	OCP\Util::writeLog('passwords', 'Passwords app blocked; no secure connection.', OCP\Util::ERROR);
 ?>
 
 	<div id="app">


### PR DESCRIPTION
Hello,

This PR fixes a bug I observed with oC 8.2.1 where the app was unable to load (blank page) with the following error message in the server log:
Class 'OC_Log' not found

The version with the PR has been tested to work with oC 8.2.1 and fixes the bug.