### PR TITLE
Block API on Passwords 16.2 and lower

### DIFF
--- a/controller/passwordapicontroller.php
+++ b/controller/passwordapicontroller.php
@@ -15,6 +15,12 @@ class PasswordApiController extends ApiController {
 	use Errors;
 
 	public function __construct($AppName, IRequest $request, PasswordService $service, $UserId) {
+		
+		$version = \OC::$server->getConfig()->getAppValue('passwords', 'installed_version', '');
+		if (version_compare($version, '17.0', '<')) {
+			return false;	
+		}
+
 		// allow getting passwords and editing/saving them
 		parent::__construct(
 			$AppName,


### PR DESCRIPTION
To fix #154.

Will block the password API if user doesn't have Passwords 17 or later installed.