### PR TITLE
Fix #296 for NextCloud11

### DIFF
--- a/templates/part.content.php
+++ b/templates/part.content.php
@@ -93,7 +93,7 @@ $version = \OC::$server->getConfig()->getAppValue('passwords', 'installed_versio
 
 	<script id="template-passwords-serialize" type="text/x-handlebars-template">
 		{{#each passwords}}
-			"website" : "{{ website }}", "pass" : "{{ pass }}", {{ properties }}, "deleted" : "{{ deleted }}", "id" : "{{ id }}", "user_id" : "{{ user_id }}"<br>
+			"website" : "{{ website }}", "pass" : "{{ pass }}", {{#if properties}}{{ properties }}{{/if}}, "deleted" : "{{ deleted }}", "id" : "{{ id }}", "user_id" : "{{ user_id }}"<br>
 		{{/each}}
 	</script>
 


### PR DESCRIPTION
The renderContent function includes the following line which was producing unexpected results:
html_passwords_serialize = $('<textarea/>').html(html_passwords_serialize).text();

This commit works around this issue.

Tested on NextCloud 11.0 (stable) and Passwords 19